### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_pad_activity_nofication_in_title/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_pad_activity_nofication_in_title/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_pad_activity_nofication_in_title/actions/workflows/test-and-release.yml)
 
-# Description
+# Pad Activity Notifications in the Browser Tab Title
 When someone edits a pad if you don't have it focused the title will be prefixed with a *.  Taking focus of that pad will remove the start prefix.
 
 ## Installation


### PR DESCRIPTION
Replace the placeholder `ep_pad_activity_nofication_in_title` heading in README.md with "Pad Activity Notifications in the Browser Tab Title" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.